### PR TITLE
Updated Compass stuff

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -15,14 +15,12 @@ $ gem install singularitygs
 Require Compass and Singularity into your Compass config.rb
 
 ```ruby
-require 'compass'
 require 'singularitygs'
 ```
 
 Import them in your stylesheets
 
 ```scss
-@import "compass";
 @import "singularitygs";
 ```
 

--- a/stylesheets/singularitygs.sass
+++ b/stylesheets/singularitygs.sass
@@ -1,4 +1,5 @@
 /*! SINGULARITY -- http://singularity.gs/ */
+@import compass
 @import modular-scale
 
 // Can be a number or a list of non-uniform column widths


### PR DESCRIPTION
Two very small changes: first, I've imported Compass at the top of `singularitygs.sass` so end users don't need to do that, and I've removed the references for `require "compass"` and `@import "compass"` from your README as the require was never needed and the `@import` is now taken care of.
