### PR TITLE
add rtl support

### DIFF
--- a/example/config.rb
+++ b/example/config.rb
@@ -1,10 +1,11 @@
 # Require any additional compass plugins here.
-load '/Users/scottkellum/Sites/Singularity/framework'
+
 # require 'singularitygs'
 require 'modular-scale'
 require 'breakpoint'
 
 # Set this to the root of your project when deployed:
+add_import_path '../stylesheets'
 http_path = 'html'
 css_dir = 'css'
 sass_dir = 'sass'

--- a/example/css/grid-span.css
+++ b/example/css/grid-span.css
@@ -1,42 +1,42 @@
 /* SINGULARITY -- http://singularity.gs/ */
 /* line 9, ../sass/grid-span.scss */
 article:nth-child(1) {
-  float: left;
   width: 20.88889%;
+  float: left;
   margin-right: 2%;
 }
 
 /* line 12, ../sass/grid-span.scss */
 article:nth-child(2) {
-  float: left;
   width: 43.11111%;
+  float: left;
   margin-right: 2%;
 }
 
 /* line 15, ../sass/grid-span.scss */
 article:nth-child(3) {
-  float: right;
   width: 32.0%;
+  float: right;
   margin-right: 0;
 }
 
 /* line 20, ../sass/grid-span.scss */
 article:nth-child(2) {
-  float: left;
   width: 43.11111%;
+  float: left;
   margin-right: 2%;
 }
 
 /* line 23, ../sass/grid-span.scss */
 article:nth-child(3) {
-  float: right;
   width: 32.0%;
+  float: right;
   margin-right: 0;
 }
 
 /* line 26, ../sass/grid-span.scss */
 article:nth-child(1) {
-  float: left;
   width: 20.88889%;
+  float: left;
   margin-right: 2%;
 }

--- a/example/css/gridset.css
+++ b/example/css/gridset.css
@@ -2,50 +2,50 @@
 /* line 11, ../sass/gridset.scss */
 #foo {
   background: red;
-  float: right;
   width: 100%;
   padding: 0 5px;
   -webkit-box-sizing: border-box;
   -moz-box-sizing: border-box;
   box-sizing: border-box;
+  float: right;
   margin-right: 0;
 }
 @media (min-width: 470px) {
   /* line 11, ../sass/gridset.scss */
   #foo {
-    float: left;
     width: 20.83333%;
     padding-left: 30px;
     padding-right: 30px;
     -webkit-box-sizing: border-box;
     -moz-box-sizing: border-box;
     box-sizing: border-box;
+    float: left;
     margin-right: 5%;
   }
 }
 @media (min-width: 800px) {
   /* line 11, ../sass/gridset.scss */
   #foo {
-    float: left;
     width: 20.57143%;
     padding-left: 15px;
     padding-right: 15px;
     -webkit-box-sizing: border-box;
     -moz-box-sizing: border-box;
     box-sizing: border-box;
+    float: left;
     margin-right: 10%;
   }
 }
 @media (min-width: 1500px) {
   /* line 11, ../sass/gridset.scss */
   #foo {
-    float: right;
     width: 33.98213%;
     padding-left: 15px;
     padding-right: 15px;
     -webkit-box-sizing: border-box;
     -moz-box-sizing: border-box;
     box-sizing: border-box;
+    float: right;
     margin-right: 0;
   }
 }

--- a/example/css/oocss-responsive.css
+++ b/example/css/oocss-responsive.css
@@ -1,202 +1,202 @@
 /* SINGULARITY -- http://singularity.gs/ */
 @media (min-width: 20em) and (max-width: 40em) {
-  /* line 48, ../../stylesheets/singularitygs/_mixins.sass */
+  /* line 64, ../../stylesheets/singularitygs/_mixins.sass */
   .a0-1, .a0-2, .a1-2 {
     float: left;
     margin-right: 2%;
   }
 
-  /* line 55, ../../stylesheets/singularitygs/_mixins.sass */
+  /* line 71, ../../stylesheets/singularitygs/_mixins.sass */
   .a0-1 {
     width: 49%;
   }
 
-  /* line 55, ../../stylesheets/singularitygs/_mixins.sass */
+  /* line 71, ../../stylesheets/singularitygs/_mixins.sass */
   .a0-2 {
     width: 99%;
     margin-right: 0;
   }
 
-  /* line 55, ../../stylesheets/singularitygs/_mixins.sass */
+  /* line 71, ../../stylesheets/singularitygs/_mixins.sass */
   .a1-2 {
     width: 49%;
     margin-right: 0;
   }
 }
 @media (min-width: 40em) and (max-width: 60em) {
-  /* line 48, ../../stylesheets/singularitygs/_mixins.sass */
+  /* line 64, ../../stylesheets/singularitygs/_mixins.sass */
   .b0-1, .b0-2, .b0-3, .b0-4, .b1-2, .b1-3, .b1-4, .b2-3, .b2-4, .b3-4 {
     float: left;
     margin-right: 1.5%;
   }
 
-  /* line 55, ../../stylesheets/singularitygs/_mixins.sass */
+  /* line 71, ../../stylesheets/singularitygs/_mixins.sass */
   .b0-1 {
     width: 32.20833%;
   }
 
-  /* line 55, ../../stylesheets/singularitygs/_mixins.sass */
+  /* line 71, ../../stylesheets/singularitygs/_mixins.sass */
   .b0-2 {
     width: 48.875%;
   }
 
-  /* line 55, ../../stylesheets/singularitygs/_mixins.sass */
+  /* line 71, ../../stylesheets/singularitygs/_mixins.sass */
   .b0-3 {
     width: 65.54167%;
   }
 
-  /* line 55, ../../stylesheets/singularitygs/_mixins.sass */
+  /* line 71, ../../stylesheets/singularitygs/_mixins.sass */
   .b0-4 {
     width: 98.875%;
     margin-right: 0;
   }
 
-  /* line 55, ../../stylesheets/singularitygs/_mixins.sass */
+  /* line 71, ../../stylesheets/singularitygs/_mixins.sass */
   .b1-2 {
     width: 15.54167%;
   }
 
-  /* line 55, ../../stylesheets/singularitygs/_mixins.sass */
+  /* line 71, ../../stylesheets/singularitygs/_mixins.sass */
   .b1-3 {
     width: 32.20833%;
   }
 
-  /* line 55, ../../stylesheets/singularitygs/_mixins.sass */
+  /* line 71, ../../stylesheets/singularitygs/_mixins.sass */
   .b1-4 {
     width: 65.54167%;
     margin-right: 0;
   }
 
-  /* line 55, ../../stylesheets/singularitygs/_mixins.sass */
+  /* line 71, ../../stylesheets/singularitygs/_mixins.sass */
   .b2-3 {
     width: 15.54167%;
   }
 
-  /* line 55, ../../stylesheets/singularitygs/_mixins.sass */
+  /* line 71, ../../stylesheets/singularitygs/_mixins.sass */
   .b2-4 {
     width: 48.875%;
     margin-right: 0;
   }
 
-  /* line 55, ../../stylesheets/singularitygs/_mixins.sass */
+  /* line 71, ../../stylesheets/singularitygs/_mixins.sass */
   .b3-4 {
     width: 32.20833%;
     margin-right: 0;
   }
 }
 @media (min-width: 60em) {
-  /* line 48, ../../stylesheets/singularitygs/_mixins.sass */
+  /* line 64, ../../stylesheets/singularitygs/_mixins.sass */
   .c0-1, .c0-2, .c0-3, .c0-4, .c0-5, .c0-6, .c1-2, .c1-3, .c1-4, .c1-5, .c1-6, .c2-3, .c2-4, .c2-5, .c2-6, .c3-4, .c3-5, .c3-6, .c4-5, .c4-6, .c5-6 {
     float: left;
     margin-right: 1%;
   }
 
-  /* line 55, ../../stylesheets/singularitygs/_mixins.sass */
+  /* line 71, ../../stylesheets/singularitygs/_mixins.sass */
   .c0-1 {
     width: 24.16667%;
   }
 
-  /* line 55, ../../stylesheets/singularitygs/_mixins.sass */
+  /* line 71, ../../stylesheets/singularitygs/_mixins.sass */
   .c0-2 {
     width: 32.5%;
   }
 
-  /* line 55, ../../stylesheets/singularitygs/_mixins.sass */
+  /* line 71, ../../stylesheets/singularitygs/_mixins.sass */
   .c0-3 {
     width: 49.16667%;
   }
 
-  /* line 55, ../../stylesheets/singularitygs/_mixins.sass */
+  /* line 71, ../../stylesheets/singularitygs/_mixins.sass */
   .c0-4 {
     width: 65.83333%;
   }
 
-  /* line 55, ../../stylesheets/singularitygs/_mixins.sass */
+  /* line 71, ../../stylesheets/singularitygs/_mixins.sass */
   .c0-5 {
     width: 74.16667%;
   }
 
-  /* line 55, ../../stylesheets/singularitygs/_mixins.sass */
+  /* line 71, ../../stylesheets/singularitygs/_mixins.sass */
   .c0-6 {
     width: 99.16667%;
     margin-right: 0;
   }
 
-  /* line 55, ../../stylesheets/singularitygs/_mixins.sass */
+  /* line 71, ../../stylesheets/singularitygs/_mixins.sass */
   .c1-2 {
     width: 7.5%;
   }
 
-  /* line 55, ../../stylesheets/singularitygs/_mixins.sass */
+  /* line 71, ../../stylesheets/singularitygs/_mixins.sass */
   .c1-3 {
     width: 24.16667%;
   }
 
-  /* line 55, ../../stylesheets/singularitygs/_mixins.sass */
+  /* line 71, ../../stylesheets/singularitygs/_mixins.sass */
   .c1-4 {
     width: 40.83333%;
   }
 
-  /* line 55, ../../stylesheets/singularitygs/_mixins.sass */
+  /* line 71, ../../stylesheets/singularitygs/_mixins.sass */
   .c1-5 {
     width: 49.16667%;
   }
 
-  /* line 55, ../../stylesheets/singularitygs/_mixins.sass */
+  /* line 71, ../../stylesheets/singularitygs/_mixins.sass */
   .c1-6 {
     width: 74.16667%;
     margin-right: 0;
   }
 
-  /* line 55, ../../stylesheets/singularitygs/_mixins.sass */
+  /* line 71, ../../stylesheets/singularitygs/_mixins.sass */
   .c2-3 {
     width: 15.83333%;
   }
 
-  /* line 55, ../../stylesheets/singularitygs/_mixins.sass */
+  /* line 71, ../../stylesheets/singularitygs/_mixins.sass */
   .c2-4 {
     width: 32.5%;
   }
 
-  /* line 55, ../../stylesheets/singularitygs/_mixins.sass */
+  /* line 71, ../../stylesheets/singularitygs/_mixins.sass */
   .c2-5 {
     width: 40.83333%;
   }
 
-  /* line 55, ../../stylesheets/singularitygs/_mixins.sass */
+  /* line 71, ../../stylesheets/singularitygs/_mixins.sass */
   .c2-6 {
     width: 65.83333%;
     margin-right: 0;
   }
 
-  /* line 55, ../../stylesheets/singularitygs/_mixins.sass */
+  /* line 71, ../../stylesheets/singularitygs/_mixins.sass */
   .c3-4 {
     width: 15.83333%;
   }
 
-  /* line 55, ../../stylesheets/singularitygs/_mixins.sass */
+  /* line 71, ../../stylesheets/singularitygs/_mixins.sass */
   .c3-5 {
     width: 24.16667%;
   }
 
-  /* line 55, ../../stylesheets/singularitygs/_mixins.sass */
+  /* line 71, ../../stylesheets/singularitygs/_mixins.sass */
   .c3-6 {
     width: 49.16667%;
     margin-right: 0;
   }
 
-  /* line 55, ../../stylesheets/singularitygs/_mixins.sass */
+  /* line 71, ../../stylesheets/singularitygs/_mixins.sass */
   .c4-5 {
     width: 7.5%;
   }
 
-  /* line 55, ../../stylesheets/singularitygs/_mixins.sass */
+  /* line 71, ../../stylesheets/singularitygs/_mixins.sass */
   .c4-6 {
     width: 32.5%;
     margin-right: 0;
   }
 
-  /* line 55, ../../stylesheets/singularitygs/_mixins.sass */
+  /* line 71, ../../stylesheets/singularitygs/_mixins.sass */
   .c5-6 {
     width: 24.16667%;
     margin-right: 0;

--- a/example/css/oocss-variable-padding.css
+++ b/example/css/oocss-variable-padding.css
@@ -1,5 +1,5 @@
 /* SINGULARITY -- http://singularity.gs/ */
-/* line 48, ../../stylesheets/singularitygs/_mixins.sass */
+/* line 64, ../../stylesheets/singularitygs/_mixins.sass */
 .a0-1, .a0-2, .a0-3, .a0-4, .a0-5, .a1-2, .a1-3, .a1-4, .a1-5, .a2-3, .a2-4, .a2-5, .a3-4, .a3-5, .a4-5 {
   float: left;
   padding: 0 1em;
@@ -9,93 +9,93 @@
   margin-right: 2%;
 }
 
-/* line 55, ../../stylesheets/singularitygs/_mixins.sass */
+/* line 71, ../../stylesheets/singularitygs/_mixins.sass */
 .a0-1 {
   width: 11.73333%;
 }
 
-/* line 55, ../../stylesheets/singularitygs/_mixins.sass */
+/* line 71, ../../stylesheets/singularitygs/_mixins.sass */
 .a0-2 {
   width: 38.4%;
   padding-right: 5%;
 }
 
-/* line 55, ../../stylesheets/singularitygs/_mixins.sass */
+/* line 71, ../../stylesheets/singularitygs/_mixins.sass */
 .a0-3 {
   width: 58.4%;
   padding-right: 10px;
 }
 
-/* line 55, ../../stylesheets/singularitygs/_mixins.sass */
+/* line 71, ../../stylesheets/singularitygs/_mixins.sass */
 .a0-4 {
   width: 91.73333%;
 }
 
-/* line 55, ../../stylesheets/singularitygs/_mixins.sass */
+/* line 71, ../../stylesheets/singularitygs/_mixins.sass */
 .a0-5 {
   width: 98.4%;
   margin-right: 0;
 }
 
-/* line 55, ../../stylesheets/singularitygs/_mixins.sass */
+/* line 71, ../../stylesheets/singularitygs/_mixins.sass */
 .a1-2 {
   width: 25.06667%;
   padding-left: 5%;
   padding-right: 5%;
 }
 
-/* line 55, ../../stylesheets/singularitygs/_mixins.sass */
+/* line 71, ../../stylesheets/singularitygs/_mixins.sass */
 .a1-3 {
   width: 45.06667%;
   padding-left: 5%;
   padding-right: 10px;
 }
 
-/* line 55, ../../stylesheets/singularitygs/_mixins.sass */
+/* line 71, ../../stylesheets/singularitygs/_mixins.sass */
 .a1-4 {
   width: 78.4%;
   padding-left: 5%;
 }
 
-/* line 55, ../../stylesheets/singularitygs/_mixins.sass */
+/* line 71, ../../stylesheets/singularitygs/_mixins.sass */
 .a1-5 {
   width: 85.06667%;
   margin-right: 0;
   padding-left: 5%;
 }
 
-/* line 55, ../../stylesheets/singularitygs/_mixins.sass */
+/* line 71, ../../stylesheets/singularitygs/_mixins.sass */
 .a2-3 {
   width: 18.4%;
   padding-left: 10px;
   padding-right: 10px;
 }
 
-/* line 55, ../../stylesheets/singularitygs/_mixins.sass */
+/* line 71, ../../stylesheets/singularitygs/_mixins.sass */
 .a2-4 {
   width: 51.73333%;
   padding-left: 10px;
 }
 
-/* line 55, ../../stylesheets/singularitygs/_mixins.sass */
+/* line 71, ../../stylesheets/singularitygs/_mixins.sass */
 .a2-5 {
   width: 58.4%;
   margin-right: 0;
   padding-left: 10px;
 }
 
-/* line 55, ../../stylesheets/singularitygs/_mixins.sass */
+/* line 71, ../../stylesheets/singularitygs/_mixins.sass */
 .a3-4 {
   width: 31.73333%;
 }
 
-/* line 55, ../../stylesheets/singularitygs/_mixins.sass */
+/* line 71, ../../stylesheets/singularitygs/_mixins.sass */
 .a3-5 {
   width: 38.4%;
   margin-right: 0;
 }
 
-/* line 55, ../../stylesheets/singularitygs/_mixins.sass */
+/* line 71, ../../stylesheets/singularitygs/_mixins.sass */
 .a4-5 {
   width: 5.06667%;
   margin-right: 0;

--- a/example/css/oosass-responsive.css
+++ b/example/css/oosass-responsive.css
@@ -1,58 +1,58 @@
 /* SINGULARITY -- http://singularity.gs/ */
 @media (min-width: 20em) and (max-width: 40em) {
-  /* line 48, ../../stylesheets/singularitygs/_mixins.sass */
+  /* line 64, ../../stylesheets/singularitygs/_mixins.sass */
   article, aside.one {
     float: left;
     margin-right: 2%;
   }
 
-  /* line 55, ../../stylesheets/singularitygs/_mixins.sass */
+  /* line 71, ../../stylesheets/singularitygs/_mixins.sass */
   article {
     width: 49%;
   }
 
-  /* line 55, ../../stylesheets/singularitygs/_mixins.sass */
+  /* line 71, ../../stylesheets/singularitygs/_mixins.sass */
   aside.one {
     width: 49%;
     margin-right: 0;
   }
 }
 @media (min-width: 40em) and (max-width: 60em) {
-  /* line 48, ../../stylesheets/singularitygs/_mixins.sass */
+  /* line 64, ../../stylesheets/singularitygs/_mixins.sass */
   article, aside.one {
     float: left;
     margin-right: 1.5%;
   }
 
-  /* line 55, ../../stylesheets/singularitygs/_mixins.sass */
+  /* line 71, ../../stylesheets/singularitygs/_mixins.sass */
   article {
     width: 65.54167%;
   }
 
-  /* line 55, ../../stylesheets/singularitygs/_mixins.sass */
+  /* line 71, ../../stylesheets/singularitygs/_mixins.sass */
   aside.one {
     width: 32.20833%;
     margin-right: 0;
   }
 }
 @media (min-width: 60em) {
-  /* line 48, ../../stylesheets/singularitygs/_mixins.sass */
+  /* line 64, ../../stylesheets/singularitygs/_mixins.sass */
   article, aside.one, aside.two {
     float: left;
     margin-right: 1%;
   }
 
-  /* line 55, ../../stylesheets/singularitygs/_mixins.sass */
+  /* line 71, ../../stylesheets/singularitygs/_mixins.sass */
   article {
     width: 65.83333%;
   }
 
-  /* line 55, ../../stylesheets/singularitygs/_mixins.sass */
+  /* line 71, ../../stylesheets/singularitygs/_mixins.sass */
   aside.one {
     width: 7.5%;
   }
 
-  /* line 55, ../../stylesheets/singularitygs/_mixins.sass */
+  /* line 71, ../../stylesheets/singularitygs/_mixins.sass */
   aside.two {
     width: 24.16667%;
     margin-right: 0;

--- a/example/css/rtl.css
+++ b/example/css/rtl.css
@@ -1,0 +1,85 @@
+/* SINGULARITY -- http://singularity.gs/ */
+/* default ltr direction */
+/* line 11, ../sass/rtl.scss */
+article:nth-child(1) {
+  width: 20.88889%;
+  float: left;
+  margin-right: 2%;
+}
+
+/* line 14, ../sass/rtl.scss */
+article:nth-child(2) {
+  width: 43.11111%;
+  float: left;
+  margin-right: 2%;
+}
+
+/* line 17, ../sass/rtl.scss */
+article:nth-child(3) {
+  width: 32.0%;
+  float: right;
+  margin-right: 0;
+}
+
+/* rtl only */
+/* line 25, ../sass/rtl.scss */
+article:nth-child(1) {
+  width: 20.88889%;
+  float: right;
+  margin-right: 0;
+  margin-left: 2%;
+}
+
+/* line 28, ../sass/rtl.scss */
+article:nth-child(2) {
+  width: 43.11111%;
+  float: right;
+  margin-right: 0;
+  margin-left: 2%;
+}
+
+/* line 31, ../sass/rtl.scss */
+article:nth-child(3) {
+  width: 32.0%;
+  float: left;
+  margin-left: 0;
+}
+
+/* both directions */
+/* line 39, ../sass/rtl.scss */
+article:nth-child(1) {
+  width: 20.88889%;
+  float: left;
+  margin-right: 2%;
+}
+/* line 50, ../../stylesheets/singularitygs/_mixins.sass */
+[dir="rtl"] article:nth-child(1) {
+  float: right;
+  margin-right: 0;
+  margin-left: 2%;
+}
+
+/* line 42, ../sass/rtl.scss */
+article:nth-child(2) {
+  width: 43.11111%;
+  float: left;
+  margin-right: 2%;
+}
+/* line 50, ../../stylesheets/singularitygs/_mixins.sass */
+[dir="rtl"] article:nth-child(2) {
+  float: right;
+  margin-right: 0;
+  margin-left: 2%;
+}
+
+/* line 45, ../sass/rtl.scss */
+article:nth-child(3) {
+  width: 32.0%;
+  float: right;
+  margin-right: 0;
+}
+/* line 39, ../../stylesheets/singularitygs/_mixins.sass */
+[dir="rtl"] article:nth-child(3) {
+  float: left;
+  margin-left: 0;
+}

--- a/example/css/scale.css
+++ b/example/css/scale.css
@@ -1,21 +1,21 @@
 /* SINGULARITY -- http://singularity.gs/ */
 /* line 9, ../sass/scale.scss */
 article:nth-child(1) {
-  float: left;
   width: 22.26217%;
+  float: left;
   margin-right: 2%;
 }
 
 /* line 12, ../sass/scale.scss */
 article:nth-child(2) {
-  float: left;
   width: 13.27341%;
+  float: left;
   margin-right: 2%;
 }
 
 /* line 15, ../sass/scale.scss */
 article:nth-child(3) {
-  float: right;
   width: 60.46442%;
+  float: right;
   margin-right: 0;
 }

--- a/example/sass/rtl.scss
+++ b/example/sass/rtl.scss
@@ -1,0 +1,48 @@
+@import "singularitygs";
+
+//list columns
+$columns: 2, 4, 3;
+// this is a list of variable widths
+
+/* default ltr direction */
+$dir: ltr;
+
+// Singularity has a built-in counter so you don’t need to define location
+article:nth-child(1) {
+  @include grid-span(1);
+}
+article:nth-child(2) {
+  @include grid-span(1);
+}
+article:nth-child(3) {
+  @include grid-span(1);
+}
+
+/* rtl only */
+$dir: rtl;
+
+// Singularity has a built-in counter so you don’t need to define location
+article:nth-child(1) {
+  @include grid-span(1);
+}
+article:nth-child(2) {
+  @include grid-span(1);
+}
+article:nth-child(3) {
+  @include grid-span(1);
+}
+
+/* both directions */
+$dir: both;
+
+// Singularity has a built-in counter so you don’t need to define location
+article:nth-child(1) {
+  @include grid-span(1);
+}
+article:nth-child(2) {
+  @include grid-span(1);
+}
+article:nth-child(3) {
+  @include grid-span(1);
+}
+

--- a/stylesheets/singularitygs.sass
+++ b/stylesheets/singularitygs.sass
@@ -12,6 +12,9 @@ $gutter: 2% !default
 // Grid padding can be any type of unit
 $padding: 0 !default
 
+// Support RTL layout flipping?
+$rtl: false !default
+
 // Helpers return think like list sums and column counts
 @import singularitygs/helpers
 
@@ -27,13 +30,13 @@ $padding: 0 !default
 // Grid math combines column and gutter math
 @import singularitygs/grid
 
-// Mixins to write 
+// Mixins to write
 @import singularitygs/mixins
 
-// Mixins to write 
+// Mixins to write
 @import singularitygs/grid-test
 
-// Mixins to write 
+// Mixins to write
 @import singularitygs/background-grid
 
 // Gridsets

--- a/stylesheets/singularitygs.sass
+++ b/stylesheets/singularitygs.sass
@@ -15,6 +15,8 @@ $padding: 0 !default
 // Layout direction?
 // options are ltr, rtl, both
 $dir: ltr !default
+// Choose a selector for rtl layouts when using 'both'
+$rtl-selector: '[dir="rtl"]' !default
 
 // Helpers return think like list sums and column counts
 @import singularitygs/helpers

--- a/stylesheets/singularitygs.sass
+++ b/stylesheets/singularitygs.sass
@@ -12,8 +12,9 @@ $gutter: 2% !default
 // Grid padding can be any type of unit
 $padding: 0 !default
 
-// Support RTL layout flipping?
-$rtl: false !default
+// Layout direction?
+// options are ltr, rtl, both
+$dir: ltr !default
 
 // Helpers return think like list sums and column counts
 @import singularitygs/helpers

--- a/stylesheets/singularitygs/_mixins.sass
+++ b/stylesheets/singularitygs/_mixins.sass
@@ -32,20 +32,29 @@ $grid-counter: 1
   $grid-counter: $location + $span
   @if $grid-counter > column-count($columns)
     $grid-counter: 1
-    float: right
-    margin-right: 0
-    @if $rtl
-      [dir="rtl"] &
-        float: left
-        margin-left: 0
+    @if $dir == ltr or $dir == both
+      float: right
+      margin-right: 0
+      @if $dir == both
+        [dir="rtl"] &
+          float: left
+          margin-left: 0
+    @if $dir == rtl
+      float: left
+      margin-left: 0
   @else
-    float: left
-    margin-right: $gutter
-    @if $rtl
-      [dir="rtl"] &
-        float: right
-        margin-right: 0
-        margin-left: $gutter
+    @if $dir == ltr or $dir == both
+      float: left
+      margin-right: $gutter
+      @if $dir == both
+        [dir="rtl"] &
+          float: right
+          margin-right: 0
+          margin-left: $gutter
+    @if $dir == rtl
+      float: right
+      margin-right: 0
+      margin-left: $gutter
 
 
 // This writes classes, IDs, or silent objects for you to extend or use in your HTML. They can be written to different breakpoints to extend or call into your HTML as needed.
@@ -80,4 +89,3 @@ $grid-counter: 1
   @if $padding != 0
     padding: 0 $padding
     +box-sizing(border-box)
-

--- a/stylesheets/singularitygs/_mixins.sass
+++ b/stylesheets/singularitygs/_mixins.sass
@@ -2,10 +2,6 @@
 $grid-counter: 1
 
 =grid-span($span, $location: $grid-counter, $columns: $columns, $gutter: $gutter, $padding: $padding)
-  @if $location < column-count($columns)
-    float: left
-  @else
-    float: right
   width: grid-span($span, $location, $columns, $gutter)
   $box-sizing: false
 
@@ -36,9 +32,20 @@ $grid-counter: 1
   $grid-counter: $location + $span
   @if $grid-counter > column-count($columns)
     $grid-counter: 1
+    float: right
     margin-right: 0
+    @if $rtl
+      [dir="rtl"] &
+        float: left
+        margin-left: 0
   @else
+    float: left
     margin-right: $gutter
+    @if $rtl
+      [dir="rtl"] &
+        float: right
+        margin-right: 0
+        margin-left: $gutter
 
 
 // This writes classes, IDs, or silent objects for you to extend or use in your HTML. They can be written to different breakpoints to extend or call into your HTML as needed.
@@ -73,3 +80,4 @@ $grid-counter: 1
   @if $padding != 0
     padding: 0 $padding
     +box-sizing(border-box)
+

--- a/stylesheets/singularitygs/_mixins.sass
+++ b/stylesheets/singularitygs/_mixins.sass
@@ -36,7 +36,7 @@ $grid-counter: 1
       float: right
       margin-right: 0
       @if $dir == both
-        [dir="rtl"] &
+        #{$rtl-selector} &
           float: left
           margin-left: 0
     @if $dir == rtl
@@ -47,7 +47,7 @@ $grid-counter: 1
       float: left
       margin-right: $gutter
       @if $dir == both
-        [dir="rtl"] &
+        #{$rtl-selector} &
           float: right
           margin-right: 0
           margin-left: $gutter


### PR DESCRIPTION
I'm working on my rtl responsive site, and this seems like the simplest solution. It's common, but not universal, practice to set a dir=rtl attribute on the `<html>` element, so this will create  an rtl option that lives alongside the ltr grid. 

You can set the `$dir` to 'ltr', 'rtl', or 'both'. (defaults to ltr) If you choose both the direction switch will be added. Otherwise the floats and margins are just set up for your layout direction. 
