### PR TITLE
Updated grid-objects mixin to write objects as prefix+span.location

### DIFF
--- a/stylesheets/singularitygs/_mixins.scss
+++ b/stylesheets/singularitygs/_mixins.scss
@@ -57,11 +57,12 @@
     @include grid-padding($padding);
     margin-right: $gutter;
   }
+// This function now labels object prefix+span.location
   @for $i from 1 through column-count($columns) {
-    @for $n from $count + 1 through column-count($columns) {
-      #{$selector}#{$prefix}#{$count}-#{$n} {
+    @for $n from 1 through (column-count($columns) - $count) {
+      #{$selector}#{$prefix}#{$n}-#{$count + 1} {
         @extend %#{$prefix}column;
-        @include grid-span($n - $count, $count + 1, $columns, $gutter);
+        @include grid-span($n, $count + 1, $columns, $gutter);
       }
     }
     $count: $count + 1;
@@ -83,18 +84,18 @@
 @mixin container($max-width: $container, $bfs: $base-font-size) {
   $bfs-length: length($bfs);
   $bfs-counter: 1;
-  
+
   @if length($containers) != 0 {
     $query: 'min-width';
     @if $grids-mobile-first == false {
       $query: 'max-width';
     }
-    
+
     $total: length($containers);
-    
+
     @if $total > 1 {
       @for $i from 2 through $total {
-        
+
         @include breakpoint((nth(nth($containers, $i), 2) $query)) {
           $bfs-holder: bfs-finder($query);
           @if unit(nth(nth($containers, $i), 1)) != '%' and $container-to-ems == true {
@@ -121,23 +122,23 @@
       max-width: $max-width;
     }
   }
-  
+
   //////////////////////////////
   // Border box and clearfix
   //////////////////////////////
   @include box-sizing(border-box);
   *behavior: url('../behaviors/box-sizing/boxsizing.php');
-  
+
   &:before,
   &:after {
     content: "";
     display: table;
   }
-  
+
   &:after {
     clear: both;
   }
-  
+
   @if $legacy-support-for-ie6 or $legacy-support-for-ie7 {
     /* for IE 6/7 */
     *zoom: expression(this.runtimeStyle.zoom="1", this.appendChild(document.createElement("br")).style.cssText="clear:both;font:0/0 serif");
@@ -156,10 +157,10 @@
   @if $grids-mobile-first == false {
     $query: 'max-width';
   }
-  
+
   html {
     font-size: nth($bfs, 1);
-    
+
     @if $bfs-length > 1 {
       @for $i from 2 through $bfs-length {
         @include breakpoint((nth(nth($bfs, $i), 2) $query)) {
@@ -176,11 +177,11 @@
 @function bfs-finder($query) {
   $context: breakpoint-get-context($query);
   $reverse: reverse($base-font-size);
-  
+
   @if $grids-mobile-first == false {
     $query: 'max-width';
   }
-  
+
   @if $query == "min-width" and $context != false {
     @each $size in $reverse {
       @if length($size) == 2 {


### PR DESCRIPTION
this update will change the syntax for the grid-object classes to better match the mixin method.  Grid classes are now 

``` css
prefix + columns spanned - starting column (new method)
```

instead of 

``` css
prefix + starting column - ending column (old method)
```
