### PR TITLE
Compound grids

### DIFF
--- a/stylesheets/singularitygs/grid-plugins/_compound.scss
+++ b/stylesheets/singularitygs/grid-plugins/_compound.scss
@@ -1,36 +1,23 @@
-@function compound($c1: 1, $c2: 1, $c3: 1, $c4: 1, $c5: 1, $c6: 1) {
-  $common-multiple: $c1 * $c2 * $c3 * $c4 * $c5 * $c6;
+// space seperated list
+@function compound($grids) {
+
+  // Find the base resolution of grid
+  $resolution: 1;
+  @each $item in $grids {
+    $resolution: $resolution * $item;
+  }
+
   $compound-grid: ();
   $compound-counter: 1;
-  @for $i from 1 through $common-multiple {
+  // cycle through each step in grid resolution
+  @for $i from 1 through $resolution {
+
+    // dont add a column by default
     $add-col: false;
-    @if $c1 != 1 {
-      @if $i / $c1 == round($i / $c1) {
-        $add-col: true;
-      }
-    }
-    @if $c2 != 1 {
-      @if $i / $c2 == round($i / $c2) {
-        $add-col: true;
-      }
-    }
-    @if $c3 != 1 {
-      @if $i / $c3 == round($i / $c3) {
-        $add-col: true;
-      }
-    }
-    @if $c4 != 1 {
-      @if $i / $c4 == round($i / $c4) {
-        $add-col: true;
-      }
-    }
-    @if $c5 != 1 {
-      @if $i / $c5 == round($i / $c5) {
-        $add-col: true;
-      }
-    }
-    @if $c6 != 1 {
-      @if $i / $c6 == round($i / $c6) {
+
+    // cycle through all grids to see if any grids match
+    @for $n from 1 through length($grids) {
+      @if $i / nth($grids, $n) == round($i / nth($grids, $n)) {
         $add-col: true;
       }
     }
@@ -44,3 +31,5 @@
   }
   @return $compound-grid;
 }
+
+@debug compound(2 3)

--- a/stylesheets/singularitygs/grid-plugins/_compound.scss
+++ b/stylesheets/singularitygs/grid-plugins/_compound.scss
@@ -16,20 +16,25 @@
     $add-col: false;
 
     // cycle through all grids to see if any grids match
-    @for $n from 1 through length($grids) {
-      @if $i / nth($grids, $n) == round($i / nth($grids, $n)) {
+    @each $grid in $grids {
+
+      // if the grid divides evenly into the resolution, add a column
+      // divide the resolution by number of columns to get the column resolution
+      @if $i / ($resolution / $grid) == round($i / ($resolution / $grid)) {
         $add-col: true;
       }
     }
+
+    // add the counter value to the compound grid list, reset counter
+    // this marks where one column ends and a new one begins
     @if $add-col {
       $compound-grid: join($compound-grid, $compound-counter, comma);
       $compound-counter: 1;
     }
+    // if no column is added, bump up counter
     @else {
       $compound-counter: $compound-counter + 1;
     }
   }
   @return $compound-grid;
 }
-
-@debug compound(2 3)

--- a/stylesheets/singularitygs/grid-plugins/_compound.scss
+++ b/stylesheets/singularitygs/grid-plugins/_compound.scss
@@ -36,5 +36,6 @@
       $compound-counter: $compound-counter + 1;
     }
   }
+  @debug "Grid compounded to #{length($compound-grid)} columns";
   @return $compound-grid;
 }

--- a/stylesheets/singularitygs/grid-plugins/_ratio.scss
+++ b/stylesheets/singularitygs/grid-plugins/_ratio.scss
@@ -16,5 +16,6 @@
     $return: reverse($return);
   }
   
+  @debug "Grid compounded to #{length($return)} columns";
   @return $return;
 }


### PR DESCRIPTION
leaner, cleaner, and more powerful compound grid function for issue #7. Supports unlimited uniform columns to compound.

It might be possible to add non-uniform column support to this.

Also added feedback that outputs the number of columns these plugin functions are writing.
### Syntax change

The syntax has changed from a coma separated list to a space separated list. This allows the grids passed through to not be limited to N slots.
##### Old

``` scss
$grid: compound(2, 3, 5);
```
##### New

``` scss
$grid: compound(2 3 5);
```
