### PR TITLE
Clearfix and border-box settings, related code cleanup

### DIFF
--- a/stylesheets/_singularitygs.scss
+++ b/stylesheets/_singularitygs.scss
@@ -43,7 +43,7 @@ $custom-clearfix: false !default;
 
 // If you're a cool kid who's using universal box-sizing: border-box set this
 // to false and Singularity won't re-declare the rule
-$set-box-sizing: true;
+$set-box-sizing: true !default;
 
 // Structural templates for grid
 $output: 'isolation' !default;

--- a/stylesheets/_singularitygs.scss
+++ b/stylesheets/_singularitygs.scss
@@ -37,6 +37,14 @@ $container-to-ems: false !default;
 // Base Font Size
 $base-font-size: 1em !default;
 
+// To use a different version of clearfix set this to true and create a
+// mixin named custom-clearfix() with your code in it
+$custom-clearfix: false !default;
+
+// If you're a cool kid who's using universal box-sizing: border-box set this
+// to false and Singularity won't re-declare the rule
+$set-box-sizing: true;
+
 // Structural templates for grid
 $output: 'isolation' !default;
 

--- a/stylesheets/_singularitygs.scss
+++ b/stylesheets/_singularitygs.scss
@@ -37,13 +37,15 @@ $container-to-ems: false !default;
 // Base Font Size
 $base-font-size: 1em !default;
 
-// To use a different version of clearfix set this to true and create a
-// mixin named custom-clearfix() with your code in it
-$custom-clearfix: false !default;
-
 // If you're a cool kid who's using universal box-sizing: border-box set this
 // to false and Singularity won't re-declare the rule
 $set-box-sizing: true !default;
+
+// Tell Singularity to use a specific version of clearfix by adding the
+// singularity-clearfix() mixin alongside your settings variables
+// @mixin singularity-clearfix {
+//   Your custom clearfix
+// }
 
 // Structural templates for grid
 $output: 'isolation' !default;

--- a/stylesheets/singularitygs/_mixins.scss
+++ b/stylesheets/singularitygs/_mixins.scss
@@ -1,3 +1,4 @@
+@import 'mixins/clearfix';
 @import 'mixins/grid-span';
 @import 'mixins/base-font-size';
 @import 'mixins/grid-build';

--- a/stylesheets/singularitygs/grid-structure/_float.scss
+++ b/stylesheets/singularitygs/grid-structure/_float.scss
@@ -9,18 +9,16 @@
     clear: both;
   }
 
-  @include clearfix;
+  @include singularity-clearfix();
 }
 
 @mixin float-common($columns: $columns, $gutter: $gutter, $padding: $padding, $grid-output-block: common) {
   @if $grid-output-block != section {
-    //@include box-sizing(border-box);
-    //*behavior: url("../behaviors/box-sizing/boxsizing.php");
-    //overflow: hidden;
-    //*zoom: 1;
 
-    // RWRW This is from personal utility. Won't work outside of it.
-    @include clearfix();
+    @if $set-box-sizing {
+      @include box-sizing(border-box);
+      *behavior: url("../behaviors/box-sizing/boxsizing.php");
+    }
 
     @if $grid-output-block == both or $grid-output-block == common {
       @if $padding != 0 {
@@ -36,8 +34,6 @@
     }
   }
 }
-
-
 
 @mixin float-section($span, $location: $grid-counter, $columns: $columns, $gutter: $gutter, $padding: $padding, $grid-output-block: section) {
   @if $grid-output-block == section or $grid-output-block == both {

--- a/stylesheets/singularitygs/grid-structure/_float.scss
+++ b/stylesheets/singularitygs/grid-structure/_float.scss
@@ -14,16 +14,19 @@
 
 @mixin float-common($columns: $columns, $gutter: $gutter, $padding: $padding, $grid-output-block: common) {
   @if $grid-output-block != section {
-    @include box-sizing(border-box);
-    *behavior: url("../behaviors/box-sizing/boxsizing.php");
-    overflow: hidden;
-    *zoom: 1;
+    //@include box-sizing(border-box);
+    //*behavior: url("../behaviors/box-sizing/boxsizing.php");
+    //overflow: hidden;
+    //*zoom: 1;
+
+    // RWRW This is from personal utility. Won't work outside of it.
+    @include clearfix();
 
     @if $grid-output-block == both or $grid-output-block == common {
       @if $padding != 0 {
         @if type-of($padding) == 'list' {
           padding-left: nth($padding, 1);
-        padding-right: nth($padding, 2);
+          padding-right: nth($padding, 2);
         }
         @else {
           padding-left: $padding;

--- a/stylesheets/singularitygs/grid-structure/_float.scss
+++ b/stylesheets/singularitygs/grid-structure/_float.scss
@@ -8,8 +8,6 @@
   @else if $dir == 'both' {
     clear: both;
   }
-
-  @include singularity-clearfix();
 }
 
 @mixin float-common($columns: $columns, $gutter: $gutter, $padding: $padding, $grid-output-block: common) {
@@ -19,6 +17,8 @@
       @include box-sizing(border-box);
       *behavior: url("../behaviors/box-sizing/boxsizing.php");
     }
+
+    @include singularity-clearfix();
 
     @if $grid-output-block == both or $grid-output-block == common {
       @if $padding != 0 {

--- a/stylesheets/singularitygs/grid-structure/_isolation.scss
+++ b/stylesheets/singularitygs/grid-structure/_isolation.scss
@@ -44,7 +44,6 @@
     }
   }
 
-
   @if $dir == ltr or $dir == both {
     @if $grid-output-block == common {
       margin-right: -100%;

--- a/stylesheets/singularitygs/grid-structure/_isolation.scss
+++ b/stylesheets/singularitygs/grid-structure/_isolation.scss
@@ -20,8 +20,6 @@
       float: left;
     }
   }
-
-  @include singularity-clearfix();
 }
 
 @mixin isolation-common($columns: $columns, $gutter: $gutter, $padding: $padding, $grid-output-block: common) {
@@ -30,6 +28,8 @@
     @include box-sizing(border-box);
     *behavior: url("../behaviors/box-sizing/boxsizing.php");
   }
+
+  @include singularity-clearfix();
 
   @if $grid-output-block == both or $grid-output-block == common {
     @if $padding != 0 {

--- a/stylesheets/singularitygs/grid-structure/_isolation.scss
+++ b/stylesheets/singularitygs/grid-structure/_isolation.scss
@@ -21,13 +21,15 @@
     }
   }
 
-  @include clearfix;
+  @include singularity-clearfix();
 }
 
 @mixin isolation-common($columns: $columns, $gutter: $gutter, $padding: $padding, $grid-output-block: common) {
-  @include box-sizing(border-box);
-  *behavior: url("../behaviors/box-sizing/boxsizing.php");
-  overflow: hidden;
+
+  @if $set-box-sizing {
+    @include box-sizing(border-box);
+    *behavior: url("../behaviors/box-sizing/boxsizing.php");
+  }
 
   @if $grid-output-block == both or $grid-output-block == common {
     @if $padding != 0 {
@@ -66,10 +68,7 @@
       }
     }
   }
-
 }
-
-
 
 @mixin isolation-section($span, $location: $grid-counter, $columns: $columns, $gutter: $gutter, $padding: $padding, $grid-output-block: section) {
   width: grid-span($span, $location, $columns, $gutter);

--- a/stylesheets/singularitygs/mixins/_clearfix.scss
+++ b/stylesheets/singularitygs/mixins/_clearfix.scss
@@ -1,10 +1,10 @@
 // Wrapper to use either custom or Compass clearfix
 // Custom must be defined by user in custom-clearfix() mixin
 @mixin singularity-clearfix() {
-  @if $custom-clearfix = true {
+  @if $custom-clearfix == true {
     @include custom-clearfix();
   }
   @else {
-    @include clearfix();
+    @include pie-clearfix();
   }
 }

--- a/stylesheets/singularitygs/mixins/_clearfix.scss
+++ b/stylesheets/singularitygs/mixins/_clearfix.scss
@@ -6,11 +6,5 @@
   }
   @else {
     @include clearfix();
-
-    // RW: This was only in _container.scss. Needed?
-    @if $legacy-support-for-ie6 or $legacy-support-for-ie7 {
-      /* for IE 6/7 */
-      *zoom: expression(this.runtimeStyle.zoom="1", this.appendChild(document.createElement("br")).style.cssText="clear:both;font:0/0 serif");
-    }
   }
 }

--- a/stylesheets/singularitygs/mixins/_clearfix.scss
+++ b/stylesheets/singularitygs/mixins/_clearfix.scss
@@ -1,10 +1,6 @@
-// Wrapper to use either custom or Compass clearfix
-// Custom must be defined by user in custom-clearfix() mixin
+// Mixin that defines Singularity's clearfix
+// Redeclare alongside Singularity settings to override
 @mixin singularity-clearfix() {
-  @if $custom-clearfix == true {
-    @include custom-clearfix();
-  }
-  @else {
-    @include pie-clearfix();
-  }
+  @include pie-clearfix();
+  *zoom: expression(this.runtimeStyle.zoom="1", this.appendChild(document.createElement("br")).style.cssText="clear:both;font:0/0 serif");
 }

--- a/stylesheets/singularitygs/mixins/_clearfix.scss
+++ b/stylesheets/singularitygs/mixins/_clearfix.scss
@@ -1,0 +1,16 @@
+// Wrapper to use either custom or Compass clearfix
+// Custom must be defined by user in custom-clearfix() mixin
+@mixin singularity-clearfix() {
+  @if $custom-clearfix = true {
+    @include custom-clearfix();
+  }
+  @else {
+    @include clearfix();
+
+    // RW: This was only in _container.scss. Needed?
+    @if $legacy-support-for-ie6 or $legacy-support-for-ie7 {
+      /* for IE 6/7 */
+      *zoom: expression(this.runtimeStyle.zoom="1", this.appendChild(document.createElement("br")).style.cssText="clear:both;font:0/0 serif");
+    }
+  }
+}

--- a/stylesheets/singularitygs/mixins/_container.scss
+++ b/stylesheets/singularitygs/mixins/_container.scss
@@ -41,23 +41,10 @@
   }
 
   // Border box and clearfix
-  @include box-sizing(border-box);
-  *behavior: url('../behaviors/box-sizing/boxsizing.php');
-
-  &:before,
-  &:after {
-    content: "";
-    display: table;
+  @if $set-box-sizing {
+    @include box-sizing(border-box);
+    *behavior: url('../behaviors/box-sizing/boxsizing.php');
   }
 
-  &:after {
-    clear: both;
-  }
-
-  @if $legacy-support-for-ie6 or $legacy-support-for-ie7 {
-    /* for IE 6/7 */
-    *zoom: expression(this.runtimeStyle.zoom="1", this.appendChild(document.createElement("br")).style.cssText="clear:both;font:0/0 serif");
-  }
-  /* non-JS fallback */
-  *zoom: 1;
+  @include singularity-clearfix();
 }

--- a/stylesheets/singularitygs/mixins/_grid-padding.scss
+++ b/stylesheets/singularitygs/mixins/_grid-padding.scss
@@ -2,7 +2,10 @@
 @mixin grid-padding($padding) {
   @if $padding != 0 {
     padding: 0 $padding;
-    @include box-sizing(border-box);
-    *behavior: url('../behaviors/box-sizing/boxsizing.php');
+
+    @if $set-box-sizing {
+      @include box-sizing(border-box);
+      *behavior: url('../behaviors/box-sizing/boxsizing.php');
+    }
   }
 }


### PR DESCRIPTION
**$set-box-sizing**
Set box-sizing rules on grid spans.  Defaults to `true`. If you've already set a universal `box-sizing:border-box;` rule, set this to false and Singularity won't re-declare the rule.

**singularity-clearfix() mixin**
Use your own version of float containment. By default Singularity uses the Compass `pie-clearfix()` mixin with an ie6-7 expression added to help normalize old ie edge cases. Because sass allows newer definitions of mixins to override old ones, redefining this mixin lets the author use a custom clearfix.

Example:

```
// A bunch of Singularity setting variables in a project's scss file

@mixin singularity-clearfix() {
  @include legacy-pie-clearfix;
}
```

Note that any clearfix include in Singularity's source code should now use the wrapper mixin `singularity-clearfix() instead`.

**Also**
Removes `overflow:hidden` and `zoom:1` rules outside of clearfix.
Moves old ie expression and clearfix to _clearfix.scss partial
Moves clearfix from float/isolation-clear mixins to float/isolation-common mixins.
Fixes https://github.com/scottkellum/Singularity/issues/69
