### PR TITLE
Add second color to background grid

### DIFF
--- a/stylesheets/singularitygs/_background-grid.scss
+++ b/stylesheets/singularitygs/_background-grid.scss
@@ -1,14 +1,22 @@
 // Write stops for single columns
 @function grid-gradient-stop($location, $columns, $gutter, $color) {
-  @if $location == 1 {
-    @return $color 0%, $color column-span(1, 1, $columns), transparentize($color, 1) column-span(1, 1, $columns);
+  $previous-span: 0% !default;
+
+  $column-span: column-span($location, 1, $columns);
+  $gutter-span: gutter-span($gutter, $columns);
+
+  @if $location != 1 {
+    $previous-span: column-span($location - 1, 1, $columns) + $gutter-span;
   }
-  @if $location == column-count($columns) {
-    @return transparentize($color, 1) column-span($location - 1, 1, $columns) + gutter-span($gutter, $columns), $color column-span($location - 1, 1, $columns) + gutter-span($gutter, $columns), $color 100%;
+
+  $gradient-stops: $color $previous-span, $color $column-span;
+
+  @if $location != column-count($columns) {
+    $gutter-stops: transparentize($color, 1) $column-span, transparentize($color, 1) ($column-span + $gutter-span);
+    $gradient-stops: join($gradient-stops, $gutter-stops, comma);
   }
-  @if $location > 1 {
-    @return transparentize($color, 1) column-span($location - 1, 1, $columns) + gutter-span($gutter, $columns), $color column-span($location - 1, 1, $columns) + gutter-span($gutter, $columns), $color column-span($location, 1, $columns), transparentize($color, 1) column-span($location, 1, $columns);
-  }
+
+  @return $gradient-stops;
 }
 
 // Compiling grid stops
@@ -23,7 +31,7 @@
 // Pull in grid stops to make a background gradient
 @mixin background-grid($columns: false, $gutter: false, $color: rgba(#69aedb, 0.5)) {
   $gl: length($grids);
-  
+
   @if $gl == 0 {
     $columns: find-grid($columns);
     $gutter: find-gutter($gutter);

--- a/stylesheets/singularitygs/_background-grid.scss
+++ b/stylesheets/singularitygs/_background-grid.scss
@@ -10,7 +10,7 @@
   }
 
   @if round($location / 2) == ($location / 2) and  $gutter-span < 1% {
-    $gradient-color: transparentize($color, (opacity($color) / 2));
+    $gradient-color: shade($color, 10%);
   }
 
   $gradient-stops: $gradient-color $previous-span, $gradient-color $column-span;

--- a/stylesheets/singularitygs/_background-grid.scss
+++ b/stylesheets/singularitygs/_background-grid.scss
@@ -1,16 +1,16 @@
 // Write stops for single columns
-@function grid-gradient-stop($location, $columns, $gutter, $color, $color2) {
+@function grid-gradient-stop($location, $columns, $gutter, $color) {
   $column-span: column-span($location, 1, $columns);
   $gutter-span: gutter-span($gutter, $columns);
-  $previous-span: 0% !default;
+  $previous-span: 0%;
   $gradient-color: $color;
 
   @if $location != 1 {
     $previous-span: column-span($location - 1, 1, $columns) + $gutter-span;
   }
 
-  @if round($location / 2) == ($location / 2) {
-    $gradient-color: $color2;
+  @if round($location / 2) == ($location / 2) and  $gutter-span < 1% {
+    $gradient-color: transparentize($color, (opacity($color) / 2));
   }
 
   $gradient-stops: $gradient-color $previous-span, $gradient-color $column-span;
@@ -24,44 +24,36 @@
 }
 
 // Compiling grid stops
-@function grid-gradient-stops($columns, $gutter, $color, $color2) {
+@function grid-gradient-stops($columns, $gutter, $color) {
   $list: ();
   @for $i from 1 through column-count($columns) {
-    $list: join($list, grid-gradient-stop($i, $columns, $gutter, $color, $color2), comma);
+    $list: join($list, grid-gradient-stop($i, $columns, $gutter, $color), comma);
   }
   @return $list;
 }
 
 // Pull in grid stops to make a background gradient
-@mixin background-grid($columns: false, $gutter: false, $color: rgba(#69aedb, 0.5), $color2: false) {
-
-  @if $color2 == false and ($gutter == 0 or $gutter == false) {
-    $color2: transparentize($color, (opacity($color) / 2));
-  }
-  @else if $color2 == false {
-    $color2: $color;
-  }
-
+@mixin background-grid($columns: false, $gutter: false, $color: rgba(#69aedb, 0.5)) {
   $gl: length($grids);
 
   @if $gl == 0 {
     $columns: find-grid($columns);
     $gutter: find-gutter($gutter);
-    @include background(linear-gradient(left, grid-gradient-stops($columns, $gutter, $color, $color2)));
+    @include background(linear-gradient(left, grid-gradient-stops($columns, $gutter, $color)));
   }
   @else {
     @for $i from 1 through $gl {
       @if $i == 1 {
         $grid: nth($grids, 1);
         $gutter: find-gutter($gutter);
-        @include background(linear-gradient(left, grid-gradient-stops($grid, $gutter, $color, $color2)));
+        @include background(linear-gradient(left, grid-gradient-stops($grid, $gutter, $color)));
       }
       @else {
         $grid: nth(nth($grids, $i), 1);
         $mq: nth(nth($grids, $i), 2);
         @include breakpoint($mq) {
           $gutter: find-gutter($gutter);
-          @include background(linear-gradient(left, grid-gradient-stops($grid, $gutter, $color, $color2)));
+          @include background(linear-gradient(left, grid-gradient-stops($grid, $gutter, $color)));
         }
       }
     }

--- a/stylesheets/singularitygs/_background-grid.scss
+++ b/stylesheets/singularitygs/_background-grid.scss
@@ -1,18 +1,22 @@
 // Write stops for single columns
-@function grid-gradient-stop($location, $columns, $gutter, $color) {
-  $previous-span: 0% !default;
-
+@function grid-gradient-stop($location, $columns, $gutter, $color, $color2) {
   $column-span: column-span($location, 1, $columns);
   $gutter-span: gutter-span($gutter, $columns);
+  $previous-span: 0% !default;
+  $gradient-color: $color;
 
   @if $location != 1 {
     $previous-span: column-span($location - 1, 1, $columns) + $gutter-span;
   }
 
-  $gradient-stops: $color $previous-span, $color $column-span;
+  @if round($location / 2) == ($location / 2) {
+    $gradient-color: $color2;
+  }
+
+  $gradient-stops: $gradient-color $previous-span, $gradient-color $column-span;
 
   @if $location != column-count($columns) {
-    $gutter-stops: transparentize($color, 1) $column-span, transparentize($color, 1) ($column-span + $gutter-span);
+    $gutter-stops: transparentize($gradient-color, 1) $column-span, transparentize($gradient-color, 1) ($column-span + $gutter-span);
     $gradient-stops: join($gradient-stops, $gutter-stops, comma);
   }
 
@@ -20,36 +24,44 @@
 }
 
 // Compiling grid stops
-@function grid-gradient-stops($columns, $gutter, $color) {
+@function grid-gradient-stops($columns, $gutter, $color, $color2) {
   $list: ();
   @for $i from 1 through column-count($columns) {
-    $list: join($list, grid-gradient-stop($i, $columns, $gutter, $color), comma);
+    $list: join($list, grid-gradient-stop($i, $columns, $gutter, $color, $color2), comma);
   }
   @return $list;
 }
 
 // Pull in grid stops to make a background gradient
-@mixin background-grid($columns: false, $gutter: false, $color: rgba(#69aedb, 0.5)) {
+@mixin background-grid($columns: false, $gutter: false, $color: rgba(#69aedb, 0.5), $color2: false) {
+
+  @if $color2 == false and ($gutter == 0 or $gutter == false) {
+    $color2: transparentize($color, (opacity($color) / 2));
+  }
+  @else if $color2 == false {
+    $color2: $color;
+  }
+
   $gl: length($grids);
 
   @if $gl == 0 {
     $columns: find-grid($columns);
     $gutter: find-gutter($gutter);
-    @include background(linear-gradient(left, grid-gradient-stops($columns, $gutter, $color)));
+    @include background(linear-gradient(left, grid-gradient-stops($columns, $gutter, $color, $color2)));
   }
   @else {
     @for $i from 1 through $gl {
       @if $i == 1 {
         $grid: nth($grids, 1);
         $gutter: find-gutter($gutter);
-        @include background(linear-gradient(left, grid-gradient-stops($grid, $gutter, $color)));
+        @include background(linear-gradient(left, grid-gradient-stops($grid, $gutter, $color, $color2)));
       }
       @else {
         $grid: nth(nth($grids, $i), 1);
         $mq: nth(nth($grids, $i), 2);
         @include breakpoint($mq) {
           $gutter: find-gutter($gutter);
-          @include background(linear-gradient(left, grid-gradient-stops($grid, $gutter, $color)));
+          @include background(linear-gradient(left, grid-gradient-stops($grid, $gutter, $color, $color2)));
         }
       }
     }


### PR DESCRIPTION
I'm making a grid with padding but no gutters, which messes with my use of the awesome `background-grid()` mixin. 

To fix this I revised `grid-gradient-stop()` to use the same logic no matter which column it's on, and then added an optional `$color2` to `background-grid()`.
- If you don't specify a `$color2`, nothing changes. 
- If you set `$color2`, odd columns are `$color` and even columns are `$color2`.
- If you don't specify a `$color2` **and** you have gutters set to 0, `$color2` is automatically set to `$color` but with 1/2 the opacity.
