### PR TITLE
add-grid(): enabled appending to arbitrary grid lists, refactored for DRY, documented

### DIFF
--- a/stylesheets/singularitygs/grids/_add.scss
+++ b/stylesheets/singularitygs/grids/_add.scss
@@ -10,7 +10,7 @@
 //                                    Defaults to $grids if none is specified.
 @function add-grid($grid-definition, $append-to-list: $grids) {
   $parsed:      parse-add($grid-definition); // Converts the definiton to a temporary format:
-                                             // either `((grid))` or `((<grid>) (<breakpoint>))`
+                                             // either `((<grid>))` or `((<grid>) (<breakpoint>))`
   $grid:        nth($parsed, 1); // E. g. `(<grid>)`.
   $breakpoint:  nth($parsed, 2); // Either `(<breakpoint>)` or false.
   $list-length: length($append-to-list);

--- a/stylesheets/singularitygs/grids/_add.scss
+++ b/stylesheets/singularitygs/grids/_add.scss
@@ -1,10 +1,29 @@
-@function add-grid($grid-definition) {
-  $parsed: parse-add($grid-definition);
-
-  @if nth($parsed, 2) == false and length($grids) == 0 {
-    @return nth($parsed, 1);
+// Accepts a grid definition in the human-readable format. Converts it to the internal format,
+// appends it to a list of grids and returns the resulting list.
+//
+// Note that this function only returns a new list, it does not modify the source list.
+//
+// add-grid($grid-definition, $append-to-list)
+// - $grid-definition : <definition>  See documentation for syntax:
+//                                    https://github.com/Team-Sass/Singularity/wiki/Creating-Grids
+// - $append-to-list  : [list]        A list to append to.
+//                                    Defaults to $grids if none is specified.
+@function add-grid($grid-definition, $append-to-list: $grids) {
+  $parsed:      parse-add($grid-definition); // Converts the definiton to a temporary format:
+                                             // either `((grid))` or `((<grid>) (<breakpoint>))`
+  $grid:        nth($parsed, 1); // E. g. `(<grid>)`.
+  $breakpoint:  nth($parsed, 2); // Either `(<breakpoint>)` or false.
+  $list-length: length($append-to-list);
+  
+  // Check whether the definition will be the first one in the list
+  // and whether it has no breakpoint specified.
+  @if $breakpoint == false and $list-length == 0 {
+    // Returns the first item of the list, e. g. `(<grid>)`
+    @return $grid;
   }
   @else {
-    @return append($grids, (nth($parsed, 1) nth($parsed, 2)), 'comma');
+    // Appends to a comma-separated list of definitions in the internal format
+    // and returns it, e. g. `(<grid>), (<grid> <breakpoint>), (<grid> <breakpoint>)`
+    @return append($append-to-list, ($grid $breakpoint), 'comma');
   }
 }

--- a/stylesheets/singularitygs/gutters/_add.scss
+++ b/stylesheets/singularitygs/gutters/_add.scss
@@ -1,10 +1,29 @@
-@function add-gutter($gutter-definition) {
-  $parsed: parse-add($gutter-definition);
+// Accepts a gutter definition in the human-readable format. Converts it to the internal format,
+// appends it to a list of gutter and returns the resulting list.
+//
+// Note that this function only returns a new list, it does not modify the source list.
+//
+// add-gutter($grid-definition, $append-to-list)
+// - $gutter-definition : <definition>  See documentation for syntax:
+//                                      https://github.com/Team-Sass/Singularity/wiki/Creating-Grids
+// - $append-to-list    : [list]        A list to append to.
+//                                      Defaults to $gutters if none is specified.
+@function add-gutter($gutter-definition, $append-to-list: $gutters) {
+  $parsed: parse-add($gutter-definition); // Converts the definiton to a temporary format:
+                                          // either `((<gutter>))` or `((<gutter>) (<breakpoint>))`
+  $gutter:      nth($parsed, 1); // E. g. `(<gutter>)`.
+  $breakpoint:  nth($parsed, 2); // Either `(<breakpoint>)` or false.
+  $list-length: length($append-to-list);
 
-  @if nth($parsed, 2) == false and length($gutters) == 0 {
-    @return nth($parsed, 1);
+  // Check whether the definition will be the first one in the list
+  // and whether it has no breakpoint specified.
+  @if $breakpoint == false and $list-length == 0 {
+    // Returns the first item of the list, e. g. `(<gutter>)`
+    @return $gutter;
   }
   @else {
-    @return append($gutters, (nth($parsed, 1) nth($parsed, 2)), 'comma');
+    // Appends to a comma-separated list of definitions in the internal format
+    // and returns it, e. g. `(<gutter>), (<gutter> <breakpoint>), (<gutter> <breakpoint>)`
+    @return append($append-to-list, ($gutter $breakpoint), 'comma');
   }
 }


### PR DESCRIPTION
1) Added an optional argument `$append-to-list` that is used as a source list for appending. This makes possible using add-grid() to assemble arbitrary grid lists in the global section of a project and then assigning any of them to $grids in partials of the layout section.

The optional argument defaults to $grids, so this change does not alter the original behavior of the function.

2) Refactored the code to remove duplicate expressions and make it much more readable.

3) Documented the function and every part of it with well-written comments.

The diff does not apply syntax highlighting, so please have a look at the modified file instead:

https://github.com/lolmaus/Singularity/blob/7ee7f5a39733a7c793087aa860666fe79f91e423/stylesheets/singularitygs/grids/_add.scss
