### PR TITLE
Fixed incorrect treatment of 'last' in float-span

### DIFF
--- a/stylesheets/singularitygs/api/_float.scss
+++ b/stylesheets/singularitygs/api/_float.scss
@@ -116,7 +116,7 @@
 
   @if type-of($grid) == 'number' and length($grid) == 1 {
     @if $location == 'last' or $location == 'omega' {
-      $location: length($grid) - $span + 1;
+      $location: $grid - $span + 1;
     }
     @else {
       @if $location == 'first' or $location == 'alpha' {


### PR DESCRIPTION
I was trying to improve Scott's StackOverflow [answer](http://stackoverflow.com/a/15864326/901944) with this code:

```
.column {
  @include float-span(1);

  &:last-child {
    @include float-span(1, 'last'); }}
```

And i found it not to be working! The last item is treated erroneously:

```
.column:last-child {
  width: 6.38298%;
  clear: right;
  float: left;
  margin-left: 0%;
  margin-right: 2.12766%;
}
```

Should be:

```
.column:last-child {
  width: 6.38298%;
  clear: right;
  float: right;
  margin-right: 0%;
}
```

I investigated the issue and found this code:

```
@if type-of($grid) == 'number' and length($grid) == 1 {
  @if $location == 'last' or $location == 'omega' {
    $location: length($grid) - $span + 1;
```

The error is in the last line. The $grid is a number, and it's list length is always 1. We want the number itself, not the 1.

So the correct line would be:

```
    $location: $grid - $span + 1;
```

Pull baby, pull! :D
