### PR TITLE
Error in float-span: SASS treating a number like a list with one element

### DIFF
--- a/stylesheets/singularitygs/api/_float.scss
+++ b/stylesheets/singularitygs/api/_float.scss
@@ -114,9 +114,14 @@
   $gutter: find-gutter($gutter);
   $row: false;
 
+  // Working around SASS treating a number like a list with one element
+  @if type-of($grid) == 'list' and length($grid) == 1 {
+    $grid: nth($grid, 1);
+  }
+
   @if type-of($grid) == 'number' and length($grid) == 1 {
     @if $location == 'last' or $location == 'omega' {
-      $location: length($grid) - $span + 1;
+      $location: $grid - $span + 1;
     }
     @else {
       @if $location == 'first' or $location == 'alpha' {


### PR DESCRIPTION
## Code

Here's the code that works perfectly:

``` sass
@import breakpoint-slicer
@import singularity

$slicer-breakpoints: 0 400px 600px 800px 1050px

$grids: 1
@for $slice from 2 through total-slices()
  $grids: add-grid($slice at bp($slice))


.column

  // Cycling through slices
  @for $slice from 2 through total-slices()

    // Setting a media query for each slice
    +at($slice)

      // Within the media query, cycle through columns
      @for $column from 1 through $slice

        // Span thumbnails in this column
        &:nth-child(#{$slice}n+#{$column})
          +float-span(1, $column)
```

By the way, that's some decent Singularity + Breakpoint Slicer usage, please check it out.

Here's the result: http://lolmaus.github.io/breakpoint-slicer/#singularity2

You can see that the grid aligns perfectly for all breakpoints.
## Problem

But i tried to use the short `float-span` syntax like this:

``` sass
      // Within the media query, cycle through columns
      // except for the last column
      @for $column from 1 through $slice - 1

        // Span thumbnails in this column
        &:nth-child(#{$slice}n+#{$column})
          +float-span(1)

      // Span thumbnails the last column
      &:nth-child(#{$slice}n+#{$slice})
        +float-span(1, last)
```

This code looks valid to me, but i receive numerous warning and thumbnails don't span:

> WARNING: Asymmetric Grids need a Location value as well as a span value in order to know where on the grid you are! Please include a location value!
> on line 138 of singularitygs/api/_float.scss, in 'float-span'
> from line with `+float-span(1)`
## Cause

The problem is that SASS treats a number like a single-element list:
- `@warn $gird` prints "4",
- `type-of($grid)` returns `list`.

Thus, neither of `float-span`'s `@if`-clauses returns true.
## Proposed solution

I added a check for this occurrence prior to main float-span logic. If $grid is a single-element list, then the element is taken out of the list and assigned to $grid.

```
// Working around SASS treating a number like a list with one element
@if type-of($grid) == 'list' and length($grid) == 1 {
  $grid: nth($grid, 1);
}
```

Another option is to put this fix into `find-grid()` instead.
## Bonus

Reapplying the fix #90 that had been [cancelled](https://github.com/Team-Sass/Singularity/commit/7aa980666c0171a8801fc20762fdf50161440897) by mistake.
