### PR TITLE
Fix to allow using float-span(1, $i) and tidying up

### DIFF
--- a/stylesheets/singularitygs/api/_float.scss
+++ b/stylesheets/singularitygs/api/_float.scss
@@ -121,14 +121,17 @@
 
   // Working with a symmetric grid
   @if type-of($grid) == 'number' {
-    @if $location == 'last' or $location == 'omega' {
-      $location: $grid - $span + 1;
-    }
-    @else {
-      @if $location == 'first' or $location == 'alpha' {
-        $row: true;
+    // Special treatment for non-numeric location
+    @if type-of($location) != 'number' {
+      @if $location == 'last' or $location == 'omega' {
+        $location: $grid - $span + 1;
       }
-      $location: 1;
+      @else {
+        @if $location == 'first' or $location == 'alpha' {
+          $row: true;
+        }
+        $location: 1;
+      }
     }
 
     @include grid-span($span, $location, $grid, $gutter, 'float');

--- a/stylesheets/singularitygs/api/_float.scss
+++ b/stylesheets/singularitygs/api/_float.scss
@@ -119,7 +119,7 @@
     $grid: nth($grid, 1);
   }
 
-  @if type-of($grid) == 'number' and length($grid) == 1 {
+  @if type-of($grid) == 'number' {
     @if $location == 'last' or $location == 'omega' {
       $location: $grid - $span + 1;
     }

--- a/stylesheets/singularitygs/api/_float.scss
+++ b/stylesheets/singularitygs/api/_float.scss
@@ -119,6 +119,7 @@
     $grid: nth($grid, 1);
   }
 
+  // Working with a symmetric grid
   @if type-of($grid) == 'number' {
     @if $location == 'last' or $location == 'omega' {
       $location: $grid - $span + 1;
@@ -136,6 +137,7 @@
       clear: both;
     }
   }
+  // Working with an asymmetric grid, should have location provided
   @else if type-of($grid) == 'list' and $location != false {
     @include grid-span($span, $location, $grid, $gutter, 'float');
   }


### PR DESCRIPTION
This pull request contains several fixes. I've filed each fix in a separate commit.
## Fix to allow using float-span(1, $i)

`float-span()` used to reset any numeric `$location` to `1`. It prevented from using the mixin in loops, e. g. `float-span(1, $i)`.

I wrapped the code that resets `$location` into an if-clause that only triggers when `$location` is not a number.
## ~~Undo spaghetti~~

~~#92 was caused by `find-grid()` returning a single element list. It was solved by adding a check for a single-element list to `float-span()`.~~

~~I moved the check from `float-span()` to `find-grid()` where it belongs.~~
## Removed a meaningless check

The second part of this if-clause was useless:

``` scss
@if type-of($grid) == 'number' and length($grid) == 1
```
## The final touch

Added some meaningful comments.
