### PR TITLE
Moving contrib guidelines into CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,7 @@
+## Contributing to Singularity
+
+We love contributors! Yes we do! If you would like to contribute to Singularity, please follow the following guidelines:
+
+* We are actively trying to stay away from Ruby functionality and am attempting to build this entirely with native Sass functionality. If you would like to add a feature that includes Ruby code, there needs to be a very very compelling case as to why.
+* Each individual feature you would like add, or bug you would like to squash, should be an individual pull request. Each pull request should be from an individual feature branch to either the latest stable or development branch. **The current *stable* branch is 1.x.x. The current *development* branch is 1.x.x**. Contributions that are not in the form of a pull request will not be considered. If your pull request does not apply cleanly we will ask you to fix that before we will look into pulling it in. We may ask you to update or make changes to the code you've submitted, please don't take this the wrong way. If a pull request smells (such as if a large amount of code is all within a single commit, or the coding standards aren't in line with core Singularity) we may ask you to rewrite your commit.
+* If you offer a new feature in a pull request and we do not feel it is a good fit for core Singularity, fret not. Singularity is designed to be extensible, and we encourage you to [build your own Compass Extension](https://github.com/Team-Sass/Compass-Extension-Template) and release your feature (if possible) as a Singularity plugin.

--- a/readme.md
+++ b/readme.md
@@ -14,14 +14,6 @@ Singularity is a next generation grid framework built from the ground up to be r
 * To file an issue with Singularity, be it a feature request or a bug report, please use our [Issue Queue](https://github.com/Team-Sass/Singularity/issues).
 * If you are in IRC, the maintainers and many fellow users tend to hang out in the #sass and #compass rooms on irc.freenode.net. Asking in there may get you a quick answer to your question, but we still encourage you to file your inquiry in the appropriate place above to 
 
-## Contributing to Singularity
-
-We love contributors! Yes we do! If you would like to contribute to Singularity, please follow the following guidelines:
-
-* We are actively trying to stay away from Ruby functionality and am attempting to build this entirely with native Sass functionality. If you would like to add a feature that includes Ruby code, there needs to be a very very compelling case as to why.
-* Each individual feature you would like add, or bug you would like to squash, should be an individual pull request. Each pull request should be from an individual feature branch to either the latest stable or development branch. **The current *stable* branch is 1.x.x. The current *development* branch is 1.x.x**. Contributions that are not in the form of a pull request will not be considered. If your pull request does not apply cleanly we will ask you to fix that before we will look into pulling it in. We may ask you to update or make changes to the code you've submitted, please don't take this the wrong way. If a pull request smells (such as if a large amount of code is all within a single commit, or the coding standards aren't in line with core Singularity) we may ask you to rewrite your commit.
-* If you offer a new feature in a pull request and we do not feel it is a good fit for core Singularity, fret not. Singularity is designed to be extensible, and we encourage you to [build your own Compass Extension](https://github.com/Team-Sass/Compass-Extension-Template) and release your feature (if possible) as a Singularity plugin.
-
 ## Singularity Plugins
 
 Having been designed to be extensible, the ability to create plugins for Singularity is great and we expect to see great things. From new [Output Span](https://github.com/Team-Sass/Singularity/wiki/Spanning-The-Grid#output-span) syntaxes to new [Output Styles](https://github.com/Team-Sass/Singularity/wiki/Output-Styles) to new [Grid Generators](https://github.com/Team-Sass/Singularity/wiki/Grid-Generators), we are excited to see what the community will come up with. Below are a list of Singularity Plugins available. If you would like to add your Plugin to the list, please issue a Pull Request to add it to the list!


### PR DESCRIPTION
Moving these guidelines into a dedicated file lets GitHub [provide some UI sugar](https://github.com/blog/1184-contributing-guidelines) during PRs. Screenshot of this very PR before I submitted is included.

![github-contributing-pr](https://f.cloud.github.com/assets/254753/433793/559a6746-aef2-11e2-9126-5420b82ac186.png)
