### PR TITLE
Declare a width value regardless of direction in isolation mode.

### DIFF
--- a/stylesheets/singularitygs/api/_isolation.scss
+++ b/stylesheets/singularitygs/api/_isolation.scss
@@ -16,14 +16,14 @@
     $margin-span: $margin-span + $gutter-span;
   }
 
-  width: column-span($span, $location, $columns, $gutter, $gutter-style);
-
   @if $direction == 'ltr' or $direction == 'both' {
     // Set the CSS direction to ltr
     $cssdir: 'ltr';
     // Find the CSS named direction and opposite direction
     $dir: named-direction($cssdir);
     $opp: opposite-direction($dir);
+    
+    width: column-span($span, $location, $columns, $gutter, $gutter-style);
 
     // If we are at the last item in the row, we float it the opposite direction
     @if ($end-row) {
@@ -86,6 +86,11 @@
     $opp: opposite-direction($dir);
 
     [dir="#{$cssdir}"] & {
+      // If we are only interested in rtl directions, add a width value
+       @if $direction == 'rtl' {
+       	 width: column-span($span, $location, $columns, $gutter, $gutter-style);
+       }
+      
       // If we are at the last item in the row, we float it the opposite direction
       @if ($end-row) {
         float: $opp;

--- a/stylesheets/singularitygs/api/_isolation.scss
+++ b/stylesheets/singularitygs/api/_isolation.scss
@@ -16,6 +16,7 @@
     $margin-span: $margin-span + $gutter-span;
   }
 
+  width: column-span($span, $location, $columns, $gutter, $gutter-style);
 
   @if $direction == 'ltr' or $direction == 'both' {
     // Set the CSS direction to ltr
@@ -23,8 +24,6 @@
     // Find the CSS named direction and opposite direction
     $dir: named-direction($cssdir);
     $opp: opposite-direction($dir);
-
-    width: column-span($span, $location, $columns, $gutter, $gutter-style);
 
     // If we are at the last item in the row, we float it the opposite direction
     @if ($end-row) {

--- a/stylesheets/singularitygs/api/_isolation.scss
+++ b/stylesheets/singularitygs/api/_isolation.scss
@@ -22,7 +22,7 @@
     // Find the CSS named direction and opposite direction
     $dir: named-direction($cssdir);
     $opp: opposite-direction($dir);
-    
+
     width: column-span($span, $location, $columns, $gutter, $gutter-style);
 
     // If we are at the last item in the row, we float it the opposite direction


### PR DESCRIPTION
Currently a width value is only printed when $direction is set to 'ltr' or 'both'  in isolation mode.  Setting $direction to 'rtl' sets margins but no width.  Which breaks the grid for rtl only sites.

Here is a gist with test Scss. https://gist.github.com/pixelwhip/6970064  I'm getting a 500 error trying to save it with sassmeister.
