### PR TITLE
Fix issue with gutters for not first and not last columns (and some spacing fixes)

### DIFF
--- a/stylesheets/singularitygs/api/_float.scss
+++ b/stylesheets/singularitygs/api/_float.scss
@@ -35,36 +35,39 @@
     @if $end-row {
       float: $opp;
       @if index($gutter-style, split) and not $fixed-gutter {
-	#{$gutter-property}-#{$dir}: 0;
-	#{$gutter-property}-#{$opp}: $gutter-span / 2;
+        #{$gutter-property}-#{$dir}: 0;
+        #{$gutter-property}-#{$opp}: $gutter-span / 2;
       }
       @else if not $fixed-gutter {
-	#{$gutter-property}-#{$opp}: 0;
+        #{$gutter-property}-#{$opp}: 0;
       }
     }
     @else {
       float: $dir;
 
       @if $start-row {
-	@if index($gutter-style, split) and not $fixed-gutter {
-	  #{$gutter-property}-#{$dir}: $gutter-span / 2;
-	  #{$gutter-property}-#{$opp}: $gutter-span / 2;
-	}
-	@else if not $fixed-gutter {
-	  #{$gutter-property}-#{$dir}: 0;
-	  #{$gutter-property}-#{$opp}: $gutter-span;
-	}
-
+        @if index($gutter-style, split) and not $fixed-gutter {
+          #{$gutter-property}-#{$dir}: $gutter-span / 2;
+          #{$gutter-property}-#{$opp}: $gutter-span / 2;
+        }
+        @else if not $fixed-gutter {
+          #{$gutter-property}-#{$dir}: 0;
+          #{$gutter-property}-#{$opp}: $gutter-span;
+        }
+      }
+      @else {
+        #{$gutter-property}-#{$dir}: 0;
+        #{$gutter-property}-#{$opp}: $gutter-span;
       }
     }
 
     @if $fixed-gutter {
       @if index($gutter-style, split) {
-	#{$gutter-property}-#{$dir}: $gutter-span / 2;
-	#{$gutter-property}-#{$opp}: $gutter-span / 2;
+        #{$gutter-property}-#{$dir}: $gutter-span / 2;
+        #{$gutter-property}-#{$opp}: $gutter-span / 2;
       }
       @else {
-	#{$gutter-property}-#{$opp}: $gutter-span;
+        #{$gutter-property}-#{$opp}: $gutter-span;
       }
     }
   }
@@ -82,41 +85,45 @@
 
       @if $end-row {
         float: $opp;
-	@if index($gutter-style, split) and not $fixed-gutter {
-	  #{$gutter-property}-#{$dir}: 0;
-	  #{$gutter-property}-#{$opp}: $gutter-span / 2;
-	}
-	@else if not $fixed-gutter {
-	  #{$gutter-property}-#{$opp}: 0;
-	}
+        @if index($gutter-style, split) and not $fixed-gutter {
+          #{$gutter-property}-#{$dir}: 0;
+          #{$gutter-property}-#{$opp}: $gutter-span / 2;
+        }
+        @else if not $fixed-gutter {
+          #{$gutter-property}-#{$opp}: 0;
+        }
       }
       @else {
         float: $dir;
 
         @if $start-row {
-	  @if index($gutter-style, split) and not $fixed-gutter {
-	    #{$gutter-property}-#{$dir}: $gutter-span / 2;
-	    #{$gutter-property}-#{$opp}: $gutter-span / 2;
-	  }
-	  @else if not $fixed-gutter {
-	    #{$gutter-property}-#{$dir}: 0;
-	    #{$gutter-property}-#{$opp}: $gutter-span;
-	  }
-	}
+          @if index($gutter-style, split) and not $fixed-gutter {
+            #{$gutter-property}-#{$dir}: $gutter-span / 2;
+            #{$gutter-property}-#{$opp}: $gutter-span / 2;
+          }
+          @else if not $fixed-gutter {
+            #{$gutter-property}-#{$dir}: 0;
+            #{$gutter-property}-#{$opp}: $gutter-span;
+          }
+        }
+        @else {
+          #{$gutter-property}-#{$dir}: 0;
+          #{$gutter-property}-#{$opp}: $gutter-span;
+        }
       }
 
       @if $fixed-gutter {
-	@if $direction == 'rtl' {
-	  @if index($gutter-style, split) {
-	    #{$gutter-property}-#{$dir}: $gutter-span / 2;
-	    #{$gutter-property}-#{$opp}: $gutter-span / 2;
-	  }
-	  @else {
-	    #{$gutter-property}-#{$opp}: $gutter-span;
-	  }
-	}
-	@else if not index($gutter-style, split) {
-	  #{$gutter-property}-#{$opp}: $gutter-span;
+        @if $direction == 'rtl' {
+          @if index($gutter-style, split) {
+            #{$gutter-property}-#{$dir}: $gutter-span / 2;
+            #{$gutter-property}-#{$opp}: $gutter-span / 2;
+          }
+          @else {
+            #{$gutter-property}-#{$opp}: $gutter-span;
+          }
+        }
+        @else if not index($gutter-style, split) {
+          #{$gutter-property}-#{$opp}: $gutter-span;
         }
       }
     }
@@ -196,8 +203,7 @@
   // Working with an asymmetric grid, should have location provided
   @else if type-of($grid) == 'list' and $location != false {
     @include grid-span($span, $location, $grid, $gutter, 'float');
-  }
-  @else {
+  } @else {
     @warn 'Asymmetric Grids need a Location value as well as a span value in order to know where on the grid you are! Please include a location value!';
   }
 }


### PR DESCRIPTION
Test css: 

``` scss
.content {  
  @include grid-span(12, 1);

  @include from(3) {
    @include layout(3 9) {
      @include grid-span(1, 2);
    }
  }

  @include from(4) {
    @include layout(3 8 1) {
      @include grid-span(2, 2);
    }
  }

  .thumbnails {
    $grids: 1;

    @for $i from 2 through total-slices() {
      $grids: add-grid($i at bp($i));
    }

    .photo {
      text-align: center;

      margin-bottom: 1em;

      @for $slice from 2 through total-slices() {
        @include at($slice) {
          @for $column from 1 through $slice {
            &:nth-child(#{$slice}n+#{$column}) {
              @include grid-span(1, $column, $output_style: float);
            }
          }
        }
      }
    }

  }

}
```

Result before fix (items starting from 2nd one displayed without margin-right):
![before](https://f.cloud.github.com/assets/108694/1394789/f32cad24-3c2e-11e3-9337-7f67f1921e92.png)

After:

![after](https://f.cloud.github.com/assets/108694/1394794/0204d128-3c2f-11e3-902f-4dc2729f02ed.png)
