### PR TITLE
Last Column Error

### DIFF
--- a/stylesheets/singularitygs/api/_float.scss
+++ b/stylesheets/singularitygs/api/_float.scss
@@ -23,7 +23,7 @@
     $Location: 1;
   }
   @else if $End-Row {
-    $Location: column-count($Grid) - $Span;
+    $Location: column-count($Grid) - $Span + 1;
   }
 
   $Width: column-span($Span, $Location, $Grid, $Gutter, $Style);

--- a/tests/controls/03-spans/03-float-span.css
+++ b/tests/controls/03-spans/03-float-span.css
@@ -112,7 +112,7 @@
     float: left;
     padding-right: 1em;
     _float-span-end: "@include float-span(1, 4)";
-    width: 31.25%;
+    width: 43.75%;
     clear: right;
     float: right;
     padding-right: 0;


### PR DESCRIPTION
if we are on the end row, Singularity assumes we are one column less than we should be. 

e.g. if our grid is 3 6 3, then we have 3 columns. We want to be in the last position so that would be 3 (column count) - 1 (the span) + 1 (since we do math our way, not computer-way) = 3. BOOM. 
